### PR TITLE
allow C++11 compilation, fix post-increment operator

### DIFF
--- a/utf.hpp
+++ b/utf.hpp
@@ -320,7 +320,7 @@ namespace utf {
             return *this;
 		}
         codepoint_iterator operator++(int) {
-            codepoint_type tmp = *this;
+            codepoint_iterator tmp = *this;
             ++(*this);
             return tmp;
         }

--- a/utf.hpp
+++ b/utf.hpp
@@ -302,7 +302,7 @@ namespace utf {
         typedef std::input_iterator_tag iterator_category;
         typedef codepoint_type value_type;
         typedef std::ptrdiff_t difference_type;
-        typedef std::remove_const_t<codepoint_type>* pointer;
+        typedef std::remove_const<codepoint_type>::type pointer;
         typedef codepoint_type& reference;
 
         explicit codepoint_iterator() : val(), pos() {}


### PR DESCRIPTION
I'm using C++11 here still, and remove_const_t is only defined in C++14. I think this statement should be the same.

Also the post-increment operator was not compiling successfully.